### PR TITLE
remove module(esm) path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandprotocol/bandchain.js",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "description": "Library for interacting with BandChain in browser and Node.js environments",
   "main": "lib/cjs/index.js",
   "types": "lib/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "1.1.5",
   "description": "Library for interacting with BandChain in browser and Node.js environments",
   "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
   "types": "lib/cjs/index.d.ts",
   "scripts": {
     "clean": "rimraf coverage lib",
-    "tsc": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
+    "tsc": "tsc -p tsconfig.cjs.json",
     "prepublish": "yarn clean && yarn tsc",
     "dev": "ts-node example/node/index.ts",
     "test": "jest --coverage",


### PR DESCRIPTION
As my research, we can build to CommonJS only. 
@tansawit Please publish to `@bandprotocol/bandchain.js` v.1.2.1