### PR TITLE
remove node 10.x test version

### DIFF
--- a/.github/workflows/bandchainjs.yaml
+++ b/.github/workflows/bandchainjs.yaml
@@ -8,7 +8,7 @@ jobs:
       working-directory: .
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - name: Code Checkout


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since the **@commitlint/cli@16.2.1** requires node ">12.x" it can cause the failure in the workflow.

### Additional context

If this is not a proper action to do, you guys can suggest another solution.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] All tests have passed
- [x] Read the [Pull Request Guidelines](https://bandprotocol.atlassian.net/l/c/5u9Sza4t) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
